### PR TITLE
DM-5879 Remove use of Boost smart pointers throughout the Science Pipelines

### DIFF
--- a/python/lsst/pex/exceptions/exceptionsLib.i
+++ b/python/lsst/pex/exceptions/exceptionsLib.i
@@ -45,7 +45,7 @@ Access to the classes from the pex_exceptions library
 %include "std_string.i"
 %include "std_vector.i"
 %include "std_iostream.i"
-%include "boost_shared_ptr.i"
+%include "std_shared_ptr.i"
 %include "carrays.i"
 %include "typemaps.i"
 

--- a/tests/testLib.i
+++ b/tests/testLib.i
@@ -41,7 +41,7 @@ Test module for pex_exceptions
 %include "std_set.i"
 %include "std_vector.i"
 %include "std_iostream.i"
-%include "boost_shared_ptr.i"
+%include "std_shared_ptr.i"
 %include "carrays.i"
 %include "typemaps.i"
 


### PR DESCRIPTION
Makes the following replacements:
- boost::scoped_ptr -> std::unique_ptr
- boost::shared_ptr -> std::shared_ptr
- boost::weak_ptr -> std::weak_ptr
- boost::static_pointer_cast -> std::static_pointer_cast
- boost::dynamic_pointer_cast -> std::dynamic_pointer_cast
- boost::const_pointer_cast -> std::const_pointer_cast
- boost::reinterpret_pointer_cast -> std::reinterpret_pointer_cast
- boost::enamble_shared_from_this -> std::enable_shared_from_this
- boost pointer related includes -> standard library memory
