### PR TITLE
DM-9435: Document uses of pex::exceptions

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,5 @@
+Copyright 2008-2015 LSST Corporation
+Copyright 2016-2017 The Trustees of Princeton University
+Copyright 2016-2017 Association of Universities for Research in Astronomy
+Copyright 2017-2018 University of Washington
+

--- a/include/lsst/pex/exceptions.h
+++ b/include/lsst/pex/exceptions.h
@@ -21,12 +21,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-/** \file
- * \brief Include files required for standard LSST Exception handling
- *
- * This include file contains include definitions of classes from the
- * exception sub-module typically needed for using standard LSST exceptions.
- */
 #ifndef LSST_PEX_EXCEPTIONS_H
 #define LSST_PEX_EXCEPTIONS_H
 #include "lsst/pex/exceptions/Exception.h"

--- a/include/lsst/pex/exceptions.h
+++ b/include/lsst/pex/exceptions.h
@@ -1,9 +1,11 @@
 /*
- * LSST Data Management System
- * Copyright 2008, 2009, 2010 LSST Corporation.
+ * This file is part of pex_exceptions.
  *
- * This product includes software developed by the
- * LSST Project (http://www.lsst.org/).
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,9 +17,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the LSST License Statement and
- * the GNU General Public License along with this program.  If not,
- * see <http://www.lsstcorp.org/LegalNotices/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 /** \file

--- a/include/lsst/pex/exceptions.h
+++ b/include/lsst/pex/exceptions.h
@@ -1,7 +1,7 @@
-/* 
+/*
  * LSST Data Management System
  * Copyright 2008, 2009, 2010 LSST Corporation.
- * 
+ *
  * This product includes software developed by the
  * LSST Project (http://www.lsst.org/).
  *
@@ -9,23 +9,23 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
- * You should have received a copy of the LSST License Statement and 
- * the GNU General Public License along with this program.  If not, 
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
  * see <http://www.lsstcorp.org/LegalNotices/>.
  */
- 
+
 /** \file
-  * \brief Include files required for standard LSST Exception handling
-  *
-  * This include file contains include definitions of classes from the 
-  * exception sub-module typically needed for using standard LSST exceptions.
-  */
+ * \brief Include files required for standard LSST Exception handling
+ *
+ * This include file contains include definitions of classes from the
+ * exception sub-module typically needed for using standard LSST exceptions.
+ */
 #ifndef LSST_PEX_EXCEPTIONS_H
 #define LSST_PEX_EXCEPTIONS_H
 #include "lsst/pex/exceptions/Exception.h"

--- a/include/lsst/pex/exceptions/Exception.h
+++ b/include/lsst/pex/exceptions/Exception.h
@@ -70,7 +70,7 @@ namespace exceptions {
     public:                                                                                   \
         t(LSST_EARGS_TYPED) : b(LSST_EARGS_UNTYPED){};                                        \
         t(std::string const& message) : b(message){};                                         \
-        virtual char const* getType(void) const throw() { return #c " *"; };                  \
+        virtual char const* getType(void) const noexcept { return #c " *"; };                 \
         virtual lsst::pex::exceptions::Exception* clone(void) const { return new t(*this); }; \
     };
 
@@ -118,7 +118,7 @@ public:
      */
     explicit Exception(std::string const& message);
 
-    virtual ~Exception(void) throw();
+    virtual ~Exception(void) noexcept;
 
     /**
      * Add a tracepoint and a message to an exception before rethrowing it (access via @ref LSST_EXCEPT_ADD).
@@ -131,7 +131,7 @@ public:
     void addMessage(char const* file, int line, char const* func, std::string const& message);
 
     /// Retrieve the list of tracepoints associated with an exception.
-    Traceback const& getTraceback(void) const throw();
+    Traceback const& getTraceback(void) const noexcept;
 
     /**
      * @brief Add a text representation of this exception, including its traceback with
@@ -152,7 +152,7 @@ public:
      *
      * @returns String representation; does not need to be freed/deleted.
      */
-    virtual char const* what(void) const throw();
+    virtual char const* what(void) const noexcept;
 
     /**
      * Return the fully-specified C++ type of a pointer to the exception.  This
@@ -161,7 +161,7 @@ public:
      *
      * @returns String with the C++ type; does not need to be freed/deleted.
      */
-    virtual char const* getType(void) const throw();
+    virtual char const* getType(void) const noexcept;
 
     /**
      * Return a copy of the exception as an Exception pointer. Can be overridden by

--- a/include/lsst/pex/exceptions/Exception.h
+++ b/include/lsst/pex/exceptions/Exception.h
@@ -36,49 +36,44 @@ namespace pex {
 namespace exceptions {
 
 /** For internal use; gathers the file, line, and function for a tracepoint.
-  */
+ */
 #define LSST_EXCEPT_HERE __FILE__, __LINE__, BOOST_CURRENT_FUNCTION
 
 /** Create an exception with a given type and message and optionally other
-  * arguments (dependent on the type).
-  * \param[in] type C++ type of the exception to be thrown.
-  */
+ * arguments (dependent on the type).
+ * \param[in] type C++ type of the exception to be thrown.
+ */
 #define LSST_EXCEPT(type, ...) type(LSST_EXCEPT_HERE, __VA_ARGS__)
 
 /** Add the current location and a message to an existing exception before
-  * rethrowing it.
-  */
+ * rethrowing it.
+ */
 #define LSST_EXCEPT_ADD(e, m) e.addMessage(LSST_EXCEPT_HERE, m)
 
 /** The initial arguments required for new exception subclasses.
-  */
-#define LSST_EARGS_TYPED \
-    char const* ex_file, int ex_line, char const* ex_func, \
-    std::string const& ex_message
+ */
+#define LSST_EARGS_TYPED char const *ex_file, int ex_line, char const *ex_func, std::string const &ex_message
 
 /** The initial arguments to the base class constructor for new subclasses.
-  */
+ */
 #define LSST_EARGS_UNTYPED ex_file, ex_line, ex_func, ex_message
 
 /** Macro used to define new types of exceptions without additional data.
-  * \param[in] t Type of the exception.
-  * \param[in] b Base class of the exception.
-  * \param[in] c C++ class of the exception (fully specified).
-  */
-#define LSST_EXCEPTION_TYPE(t, b, c) \
-    class t : public b { \
-    public: \
-        t(LSST_EARGS_TYPED) : b(LSST_EARGS_UNTYPED) { }; \
-        t(std::string const & message) : b(message) { }; \
-        virtual char const* getType(void) const throw() { return #c " *"; }; \
-        virtual lsst::pex::exceptions::Exception* clone(void) const { \
-            return new t(*this); \
-        }; \
+ * \param[in] t Type of the exception.
+ * \param[in] b Base class of the exception.
+ * \param[in] c C++ class of the exception (fully specified).
+ */
+#define LSST_EXCEPTION_TYPE(t, b, c)                                                          \
+    class t : public b {                                                                      \
+    public:                                                                                   \
+        t(LSST_EARGS_TYPED) : b(LSST_EARGS_UNTYPED){};                                        \
+        t(std::string const& message) : b(message){};                                         \
+        virtual char const* getType(void) const throw() { return #c " *"; };                  \
+        virtual lsst::pex::exceptions::Exception* clone(void) const { return new t(*this); }; \
     };
 
 /// One point in the Traceback vector held by Exception
 struct Tracepoint {
-
     /** Standard constructor, intended for C++ use.
      *
      * @param[in] file Filename.
@@ -86,19 +81,17 @@ struct Tracepoint {
      * @param[in] func Function name.
      * @param[in] message Informational string attached to exception.
      */
-    Tracepoint(char const* file, int line, char const* func,
-               std::string const & message);
+    Tracepoint(char const* file, int line, char const* func, std::string const& message);
 
-    char const* _file; // Compiled strings only; does not need deletion
+    char const* _file;  // Compiled strings only; does not need deletion
     int _line;
-    char const* _func; // Compiled strings only; does not need deletion
+    char const* _func;  // Compiled strings only; does not need deletion
     std::string _message;
 };
 typedef std::vector<Tracepoint> Traceback;
 
 class Exception : public std::exception {
 public:
-
     /** Standard constructor, intended for C++ use via the LSST_EXCEPT() macro.
      *
      * @param[in] file Filename (automatically passed in by macro).
@@ -107,7 +100,7 @@ public:
      * @param[in] message Informational string attached to exception.
      */
     Exception(char const* file, int line, char const* func,
-              std::string const& message); // Should use LSST_EARGS_TYPED, but that confuses doxygen.
+              std::string const& message);  // Should use LSST_EARGS_TYPED, but that confuses doxygen.
 
     /** Message-only constructor, intended for use from Python only.
      *
@@ -118,7 +111,7 @@ public:
      *
      * @param[in] message Informational string attached to exception.
      */
-    explicit Exception(std::string const & message);
+    explicit Exception(std::string const& message);
 
     virtual ~Exception(void) throw();
 
@@ -129,8 +122,7 @@ public:
      * @param[in] func Function name (automatically passed in by macro).
      * @param[in] message Additional message to associate with this rethrow.
      */
-    void addMessage(char const* file, int line, char const* func,
-                    std::string const& message);
+    void addMessage(char const* file, int line, char const* func, std::string const& message);
 
     /// Retrieve the list of tracepoints associated with an exception.
     Traceback const& getTraceback(void) const throw();
@@ -176,12 +168,13 @@ private:
 };
 
 /** Push the text representation of an exception onto a stream.
-  * @param[in] stream Reference to an output stream.
-  * @param[in] e Exception to output.
-  * @return Reference to the output stream after adding the text.
-  */
+ * @param[in] stream Reference to an output stream.
+ * @param[in] e Exception to output.
+ * @return Reference to the output stream after adding the text.
+ */
 std::ostream& operator<<(std::ostream& stream, Exception const& e);
-
-}}} // namespace lsst::pex::exceptions
+}
+}  // namespace pex
+}  // namespace lsst
 
 #endif

--- a/include/lsst/pex/exceptions/Exception.h
+++ b/include/lsst/pex/exceptions/Exception.h
@@ -1,10 +1,11 @@
-// -*- LSST-C++ -*-
 /*
- * LSST Data Management System
- * Copyright 2008-2014 LSST Corporation.
+ * This file is part of pex_exceptions.
  *
- * This product includes software developed by the
- * LSST Project (http://www.lsst.org/).
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,9 +17,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the LSST License Statement and
- * the GNU General Public License along with this program.  If not,
- * see <http://www.lsstcorp.org/LegalNotices/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef LSST_PEX_EXCEPTIONS_EXCEPTION_H

--- a/include/lsst/pex/exceptions/Exception.h
+++ b/include/lsst/pex/exceptions/Exception.h
@@ -35,33 +35,35 @@ namespace lsst {
 namespace pex {
 namespace exceptions {
 
-/** For internal use; gathers the file, line, and function for a tracepoint.
- */
+/// For internal use; gathers the file, line, and function for a tracepoint.
 #define LSST_EXCEPT_HERE __FILE__, __LINE__, BOOST_CURRENT_FUNCTION
 
-/** Create an exception with a given type and message and optionally other
- * arguments (dependent on the type).
- * \param[in] type C++ type of the exception to be thrown.
+/**
+ * Create an exception with a given type.
+ *
+ * @param[in] type C++ type of the exception to be thrown.
+ * @param[in] ... The message, and optionally other arguments (dependent on the type).
  */
 #define LSST_EXCEPT(type, ...) type(LSST_EXCEPT_HERE, __VA_ARGS__)
 
-/** Add the current location and a message to an existing exception before
+/**
+ * @brief Add the current location and a message to an existing exception before
  * rethrowing it.
  */
 #define LSST_EXCEPT_ADD(e, m) e.addMessage(LSST_EXCEPT_HERE, m)
 
-/** The initial arguments required for new exception subclasses.
- */
+/// The initial arguments required for new exception subclasses.
 #define LSST_EARGS_TYPED char const *ex_file, int ex_line, char const *ex_func, std::string const &ex_message
 
-/** The initial arguments to the base class constructor for new subclasses.
- */
+/// The initial arguments to the base class constructor for new subclasses.
 #define LSST_EARGS_UNTYPED ex_file, ex_line, ex_func, ex_message
 
-/** Macro used to define new types of exceptions without additional data.
- * \param[in] t Type of the exception.
- * \param[in] b Base class of the exception.
- * \param[in] c C++ class of the exception (fully specified).
+/**
+ * Macro used to define new types of exceptions without additional data.
+ *
+ * @param[in] t Type of the exception.
+ * @param[in] b Base class of the exception.
+ * @param[in] c C++ class of the exception (fully specified).
  */
 #define LSST_EXCEPTION_TYPE(t, b, c)                                                          \
     class t : public b {                                                                      \
@@ -74,7 +76,8 @@ namespace exceptions {
 
 /// One point in the Traceback vector held by Exception
 struct Tracepoint {
-    /** Standard constructor, intended for C++ use.
+    /**
+     * Standard constructor, intended for C++ use.
      *
      * @param[in] file Filename.
      * @param[in] line Line number.
@@ -92,7 +95,8 @@ typedef std::vector<Tracepoint> Traceback;
 
 class Exception : public std::exception {
 public:
-    /** Standard constructor, intended for C++ use via the LSST_EXCEPT() macro.
+    /**
+     * Standard constructor, intended for C++ use via the LSST_EXCEPT() macro.
      *
      * @param[in] file Filename (automatically passed in by macro).
      * @param[in] line Line number (automatically passed in by macro).
@@ -102,9 +106,10 @@ public:
     Exception(char const* file, int line, char const* func,
               std::string const& message);  // Should use LSST_EARGS_TYPED, but that confuses doxygen.
 
-    /** Message-only constructor, intended for use from Python only.
+    /**
+     * Message-only constructor, intended for use from Python only.
      *
-     * While this constructor can be called from C++, it's better to use the LSST_EXCEPT
+     * While this constructor can be called from C++, it's better to use the @ref LSST_EXCEPT
      * macro there, which stores file/line/function information as well.  In Python, however,
      * that information is stored outside the exception, so we don't want to duplicate it,
      * and hence this constructor is invoked instead.
@@ -115,7 +120,8 @@ public:
 
     virtual ~Exception(void) throw();
 
-    /** Add a tracepoint and a message to an exception before rethrowing it (access via LSST_EXCEPT_ADD).
+    /**
+     * Add a tracepoint and a message to an exception before rethrowing it (access via @ref LSST_EXCEPT_ADD).
      *
      * @param[in] file Filename (automatically passed in by macro).
      * @param[in] line Line number (automatically passed in by macro).
@@ -127,38 +133,41 @@ public:
     /// Retrieve the list of tracepoints associated with an exception.
     Traceback const& getTraceback(void) const throw();
 
-    /** Add a text representation of this exception, including its traceback with
-     *  messages, to a stream.
+    /**
+     * @brief Add a text representation of this exception, including its traceback with
+     * messages, to a stream.
      *
      * @param[in] stream Reference to an output stream.
-     * @return Reference to the output stream after adding the text.
+     * @returns Reference to the output stream after adding the text.
      */
     virtual std::ostream& addToStream(std::ostream& stream) const;
 
     /**
-     *  Return a character string summarizing this exception.
+     * Return a character string summarizing this exception.
      *
-     *  This combines all the messages added to the exception, but not the type or
-     *  traceback (use the stream operator to get this more detailed information).
+     * This combines all the messages added to the exception, but not the type or
+     * traceback (use the stream operator to get this more detailed information).
      *
-     *  Not allowed to throw any exceptions.
+     * Not allowed to throw any exceptions.
      *
-     *  @return String representation; does not need to be freed/deleted.
+     * @returns String representation; does not need to be freed/deleted.
      */
     virtual char const* what(void) const throw();
 
-    /** Return the fully-specified C++ type of a pointer to the exception.  This
-     *  is overridden by derived classes (automatically if the LSST_EXCEPTION_TYPE
-     *  macro is used).  It is used by the Python interface.
+    /**
+     * Return the fully-specified C++ type of a pointer to the exception.  This
+     * is overridden by derived classes (automatically if the @ref LSST_EXCEPTION_TYPE
+     * macro is used).  It is used by the Python interface.
      *
-     *  @return String with the C++ type; does not need to be freed/deleted.
+     * @returns String with the C++ type; does not need to be freed/deleted.
      */
     virtual char const* getType(void) const throw();
 
-    /** Return a copy of the exception as an Exception*.  Can be overridden by
-     *  derived classes that add data or methods.
+    /**
+     * Return a copy of the exception as an Exception pointer. Can be overridden by
+     * derived classes that add data or methods.
      *
-     *  @return Exception* pointing to a copy of the exception.
+     * @returns Pointer to a copy of the exception.
      */
     virtual Exception* clone(void) const;
 
@@ -167,10 +176,12 @@ private:
     Traceback _traceback;
 };
 
-/** Push the text representation of an exception onto a stream.
+/**
+ * Push the text representation of an exception onto a stream.
+ *
  * @param[in] stream Reference to an output stream.
  * @param[in] e Exception to output.
- * @return Reference to the output stream after adding the text.
+ * @returns Reference to the output stream after adding the text.
  */
 std::ostream& operator<<(std::ostream& stream, Exception const& e);
 }

--- a/include/lsst/pex/exceptions/Exception.h
+++ b/include/lsst/pex/exceptions/Exception.h
@@ -93,6 +93,16 @@ struct Tracepoint {
 };
 typedef std::vector<Tracepoint> Traceback;
 
+/**
+ * Provides consistent interface for LSST exceptions.
+ *
+ * All exceptions defined by the LSST Stack are derived from this class. Code
+ * should not throw or catch Exception directly, but should instead be written
+ * in terms of the appropriate subclasses (e.g., catch RuntimeError to handle
+ * all unknown errors).
+ *
+ * In Python, this exception inherits from `__builtin__.Exception`.
+ */
 class Exception : public std::exception {
 public:
     /**

--- a/include/lsst/pex/exceptions/Runtime.h
+++ b/include/lsst/pex/exceptions/Runtime.h
@@ -1,11 +1,11 @@
-// -*- lsst-c++ -*-
-
 /*
- * LSST Data Management System
- * Copyright 2008, 2009, 2010 LSST Corporation.
+ * This file is part of pex_exceptions.
  *
- * This product includes software developed by the
- * LSST Project (http://www.lsst.org/).
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,9 +17,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the LSST License Statement and
- * the GNU General Public License along with this program.  If not,
- * see <http://www.lsstcorp.org/LegalNotices/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #if !defined(LSST_RUNTIME_EXCEPTION)

--- a/include/lsst/pex/exceptions/Runtime.h
+++ b/include/lsst/pex/exceptions/Runtime.h
@@ -1,9 +1,9 @@
 // -*- lsst-c++ -*-
 
-/* 
+/*
  * LSST Data Management System
  * Copyright 2008, 2009, 2010 LSST Corporation.
- * 
+ *
  * This product includes software developed by the
  * LSST Project (http://www.lsst.org/).
  *
@@ -11,17 +11,17 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
- * You should have received a copy of the LSST License Statement and 
- * the GNU General Public License along with this program.  If not, 
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
  * see <http://www.lsstcorp.org/LegalNotices/>.
  */
- 
+
 #if !defined(LSST_RUNTIME_EXCEPTION)
 #define LSST_RUNTIME_EXCEPTION 1
 
@@ -46,8 +46,8 @@ LSST_EXCEPTION_TYPE(NotFoundError, Exception, lsst::pex::exceptions::NotFoundErr
 LSST_EXCEPTION_TYPE(IoError, RuntimeError, lsst::pex::exceptions::IoError)
 LSST_EXCEPTION_TYPE(TypeError, RuntimeError, lsst::pex::exceptions::TypeError)
 
-}
-}
-}
+}  // namespace exceptions
+}  // namespace pex
+}  // namespace lsst
 
 #endif

--- a/include/lsst/pex/exceptions/Runtime.h
+++ b/include/lsst/pex/exceptions/Runtime.h
@@ -32,17 +32,138 @@ namespace lsst {
 namespace pex {
 namespace exceptions {
 
+/**
+ * Reports errors in the logical structure of the program.
+ *
+ * LogicError and its subclasses should be thrown to represent problems, such
+ * as violation of logical preconditions or class invariants, that are in
+ * principle preventable using defensive programming or other good practices.
+ * In many cases, it may not be appropriate to catch them.
+ *
+ * @see RuntimeError
+ * @see std::logic_error
+ */
 LSST_EXCEPTION_TYPE(LogicError, Exception, lsst::pex::exceptions::LogicError)
+
+/**
+ * Reports arguments outside the domain of an operation.
+ *
+ * This exception should be reserved for mathematical operations that are
+ * defined on a limited range of inputs. InvalidParameterError is more
+ * appropriate for non-mathematical operations.
+ *
+ * @see std::domain_error
+ */
 LSST_EXCEPTION_TYPE(DomainError, LogicError, lsst::pex::exceptions::DomainError)
+
+/**
+ * Reports invalid arguments.
+ *
+ * This exception reports errors that arise because an argument value has not been accepted.
+ *
+ * @see std::invalid_argument
+ */
 LSST_EXCEPTION_TYPE(InvalidParameterError, LogicError, lsst::pex::exceptions::InvalidParameterError)
+
+/**
+ * Reports attempts to exceed implementation-defined length limits for some classes.
+ *
+ * For example, some collection classes might not be able to handle more than
+ * some number of elements, or bit fields might support a limited number of flags.
+ *
+ * @see std::length_error
+ */
 LSST_EXCEPTION_TYPE(LengthError, LogicError, lsst::pex::exceptions::LengthError)
+
+/**
+ * Reports attempts to access elements outside a valid range of indices.
+ *
+ * @see NotFoundError
+ * @see std::out_of_range
+ *
+ * @note pybind11 wrappers should manually translate this exception to
+ * `py::index_error` when appropriate. Some Python language constructs check
+ * for exceptions that are exactly `IndexError` rather than a
+ * sub- or superclass.
+ */
 LSST_EXCEPTION_TYPE(OutOfRangeError, LogicError, lsst::pex::exceptions::OutOfRangeError)
+
+/**
+ * Reports errors that are due to events beyond the control of the program.
+ *
+ * RuntimeError and its subclasses represent problems that cannot be easily
+ * predicted or prevented. In other words, a RuntimeError is a possible outcome
+ * of calling a function or method even in well-written programs, and should be
+ * handled at the appropriate level.
+ *
+ * In Python, this exception inherits from `__builtin__.RuntimeError`.
+ *
+ * @see LogicError
+ * @see std::runtime_error
+ */
 LSST_EXCEPTION_TYPE(RuntimeError, Exception, lsst::pex::exceptions::RuntimeError)
+
+/**
+ * Reports when the result of an operation cannot be represented by the destination type.
+ *
+ * Situations covered by this exception include lossy type conversions.
+ *
+ * @see OverflowError
+ * @see UnderflowError
+ * @see std::range_error
+ */
 LSST_EXCEPTION_TYPE(RangeError, RuntimeError, lsst::pex::exceptions::RangeError)
+
+/**
+ * Reports when the result of an arithmetic operation is too large for the destination type.
+ *
+ * In Python, this exception inherits from `__builtin__.OverflowError`.
+ *
+ * @see std::overflow_error
+ */
 LSST_EXCEPTION_TYPE(OverflowError, RuntimeError, lsst::pex::exceptions::OverflowError)
+
+/**
+ * Reports when the result of an arithmetic operation is too small for the destination type.
+ *
+ * In Python, this exception inherits from `__builtin__.ArithmeticError`.
+ *
+ * @see std::underflow_error
+ */
 LSST_EXCEPTION_TYPE(UnderflowError, RuntimeError, lsst::pex::exceptions::UnderflowError)
+
+/**
+ * Reports attempts to access elements using an invalid key.
+ *
+ * This exception may represent lookup failures in classes that resemble C++
+ * maps or Python dictionaries, but it may also be used when the relationship
+ * between an identifier and a resource is more abstract.
+ *
+ * In Python, this exception inherits from `__builtin__.LookupError`.
+ *
+ * @see OutOfRangeError
+ *
+ * @note pybind11 wrappers should manually translate this exception to
+ * `py::key_error` when appropriate. Some Python language constructs check
+ * for exceptions that are exactly `KeyError` rather than a
+ * sub- or superclass.
+ */
 LSST_EXCEPTION_TYPE(NotFoundError, Exception, lsst::pex::exceptions::NotFoundError)
+
+/**
+ * Reports errors in external input/output operations.
+ *
+ * In Python, this exception inherits from `__builtin__.IOError`.
+ *
+ * @see std::ios_base::failure
+ */
 LSST_EXCEPTION_TYPE(IoError, RuntimeError, lsst::pex::exceptions::IoError)
+
+/**
+ * Reports errors from accepting an object of an unexpected or inappropriate type.
+ *
+ * In Python, this exception inherits from `__builtin__.TypeError`.
+ */
 LSST_EXCEPTION_TYPE(TypeError, RuntimeError, lsst::pex::exceptions::TypeError)
 
 }  // namespace exceptions

--- a/include/lsst/pex/exceptions/Runtime.h
+++ b/include/lsst/pex/exceptions/Runtime.h
@@ -164,7 +164,7 @@ LSST_EXCEPTION_TYPE(IoError, RuntimeError, lsst::pex::exceptions::IoError)
  *
  * In Python, this exception inherits from `__builtin__.TypeError`.
  */
-LSST_EXCEPTION_TYPE(TypeError, RuntimeError, lsst::pex::exceptions::TypeError)
+LSST_EXCEPTION_TYPE(TypeError, LogicError, lsst::pex::exceptions::TypeError)
 
 }  // namespace exceptions
 }  // namespace pex

--- a/include/lsst/pex/exceptions/asserts.h
+++ b/include/lsst/pex/exceptions/asserts.h
@@ -26,13 +26,14 @@
 #include "lsst/pex/exceptions/Exception.h"
 
 /**
- *  Check whether the given values are equal, and throw an LSST Exception with the given message
- *  (which must include two Boost.Format placeholders for the two numbers) if they are not.
+ * Check whether the given values are equal, and throw an LSST Exception if they are not.
  *
- *  For example:
- *  @code
- *  LSST_ASSERT_EQUAL(3, 4, "size of foo (%d) is not equal to size of bar (%d)", LengthError);
- *  @endcode
+ * The given message must include two Boost.Format placeholders for the two numbers.
+ *
+ * For example:
+ *
+ *     LSST_THROW_IF_NE(3, 4, LengthError, "size of foo (%d) is not equal to size of bar (%d)");
+ *
  */
 #define LSST_THROW_IF_NE(N1, N2, EXC_CLASS, MSG) \
     if ((N1) != (N2)) throw LSST_EXCEPT(EXC_CLASS, (boost::format(MSG) % (N1) % (N2)).str())

--- a/include/lsst/pex/exceptions/asserts.h
+++ b/include/lsst/pex/exceptions/asserts.h
@@ -34,5 +34,5 @@
  *  LSST_ASSERT_EQUAL(3, 4, "size of foo (%d) is not equal to size of bar (%d)", LengthError);
  *  @endcode
  */
-#define LSST_THROW_IF_NE(N1, N2, EXC_CLASS, MSG)                        \
+#define LSST_THROW_IF_NE(N1, N2, EXC_CLASS, MSG) \
     if ((N1) != (N2)) throw LSST_EXCEPT(EXC_CLASS, (boost::format(MSG) % (N1) % (N2)).str())

--- a/include/lsst/pex/exceptions/asserts.h
+++ b/include/lsst/pex/exceptions/asserts.h
@@ -1,10 +1,11 @@
-// -*- lsst-c++ -*-
 /*
- * LSST Data Management System
- * Copyright 2008-2013 LSST Corporation.
+ * This file is part of pex_exceptions.
  *
- * This product includes software developed by the
- * LSST Project (http://www.lsst.org/).
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,9 +17,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the LSST License Statement and
- * the GNU General Public License along with this program.  If not,
- * see <http://www.lsstcorp.org/LegalNotices/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include "boost/format.hpp"

--- a/include/lsst/pex/exceptions/python/Exception.h
+++ b/include/lsst/pex/exceptions/python/Exception.h
@@ -1,8 +1,8 @@
 // -*- LSST-C++ -*-
-/* 
+/*
  * LSST Data Management System
  * Copyright 2008-2016  AURA/LSST.
- * 
+ *
  * This product includes software developed by the
  * LSST Project (http://www.lsst.org/).
  *
@@ -10,14 +10,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
- * You should have received a copy of the LSST License Statement and 
- * the GNU General Public License along with this program.  If not, 
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
  * see <https://www.lsstcorp.org/LegalNotices/>.
  */
 
@@ -36,15 +36,16 @@ namespace exceptions {
 namespace python {
 
 /** Helper function for pybind11, used to define new types of exceptions.
-  * \param[in] mod Module to insert the exception into.
-  * \param[in] name Name of the exception in the module.
-  * \param[in] base Python name of base class (from pex exceptions).
-  *
-  * While this function creates the class wrapper, the user is still responsible
-  * for adding all constructor and member wrappers to the returned py::class_ object.
-  */
-template <typename T, typename E=lsst::pex::exceptions::Exception>
-pybind11::class_<T> declareException(pybind11::module &mod, const std::string & name, const std::string & base) {
+ * \param[in] mod Module to insert the exception into.
+ * \param[in] name Name of the exception in the module.
+ * \param[in] base Python name of base class (from pex exceptions).
+ *
+ * While this function creates the class wrapper, the user is still responsible
+ * for adding all constructor and member wrappers to the returned py::class_ object.
+ */
+template <typename T, typename E = lsst::pex::exceptions::Exception>
+pybind11::class_<T> declareException(pybind11::module &mod, const std::string &name,
+                                     const std::string &base) {
     namespace py = pybind11;
 
     // Wrap T as a new Python exception type with *name* and add it to the module
@@ -53,36 +54,37 @@ pybind11::class_<T> declareException(pybind11::module &mod, const std::string & 
     // It is only in the pure Python wrapper layer that they get embedded in
     // a subclass of the requested base.
     py::class_<T, E> cls(mod, name.c_str());
-    
+
     // Declare T wrapped by cls as a pex exception and register it
     // this relies on the pure Python function "declare" defined in "wrappers"
     // to create a corresponding Python type derived from Python standard Exception
-    auto exceptions = py::reinterpret_steal<py::object>(PyImport_ImportModule("lsst.pex.exceptions.wrappers"));
+    auto exceptions =
+            py::reinterpret_steal<py::object>(PyImport_ImportModule("lsst.pex.exceptions.wrappers"));
     if (!exceptions.ptr()) {
         PyErr_SetString(PyExc_SystemError, "import failed");
         throw py::error_already_set();
-    }   
+    }
 
     auto declare = py::reinterpret_steal<py::object>(PyObject_GetAttrString(exceptions.ptr(), "declare"));
     if (!declare.ptr()) {
         PyErr_SetString(PyExc_SystemError, "could not get declare function from Python");
         throw py::error_already_set();
-    }   
+    }
 
     auto baseCls = py::reinterpret_steal<py::object>(PyObject_GetAttrString(exceptions.ptr(), base.c_str()));
     if (!baseCls.ptr()) {
         PyErr_SetString(PyExc_SystemError, "could not get base class");
         throw py::error_already_set();
-    }   
+    }
 
     auto exceptionName = py::reinterpret_steal<py::object>(PYBIND11_FROM_STRING(name.c_str()));
     if (!exceptionName.ptr()) {
         PyErr_SetString(PyExc_SystemError, "could not create name string");
         throw py::error_already_set();
-    }   
+    }
 
-    auto result = py::reinterpret_steal<py::object>(PyObject_CallFunctionObjArgs(declare.ptr(), mod.ptr(),
-            exceptionName.ptr(), baseCls.ptr(), cls.ptr(), NULL));
+    auto result = py::reinterpret_steal<py::object>(PyObject_CallFunctionObjArgs(
+            declare.ptr(), mod.ptr(), exceptionName.ptr(), baseCls.ptr(), cls.ptr(), NULL));
     if (!result.ptr()) {
         PyErr_SetString(PyExc_SystemError, "could not declare exception");
         throw py::error_already_set();
@@ -91,6 +93,9 @@ pybind11::class_<T> declareException(pybind11::module &mod, const std::string & 
     return cls;
 }
 
-}}}} // namespace lsst::pex::exceptions::python
+}  // namespace python
+}  // namespace exceptions
+}  // namespace pex
+}  // namespace lsst
 
 #endif

--- a/include/lsst/pex/exceptions/python/Exception.h
+++ b/include/lsst/pex/exceptions/python/Exception.h
@@ -1,10 +1,11 @@
-// -*- LSST-C++ -*-
 /*
- * LSST Data Management System
- * Copyright 2008-2016  AURA/LSST.
+ * This file is part of pex_exceptions.
  *
- * This product includes software developed by the
- * LSST Project (http://www.lsst.org/).
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,9 +17,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the LSST License Statement and
- * the GNU General Public License along with this program.  If not,
- * see <https://www.lsstcorp.org/LegalNotices/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef LSST_PEX_EXCEPTIONS_PYTHON_EXCEPTION_H

--- a/include/lsst/pex/exceptions/python/Exception.h
+++ b/include/lsst/pex/exceptions/python/Exception.h
@@ -35,13 +35,18 @@ namespace pex {
 namespace exceptions {
 namespace python {
 
-/** Helper function for pybind11, used to define new types of exceptions.
- * \param[in] mod Module to insert the exception into.
- * \param[in] name Name of the exception in the module.
- * \param[in] base Python name of base class (from pex exceptions).
+/**
+ * Helper function for pybind11, used to define new types of exceptions.
  *
  * While this function creates the class wrapper, the user is still responsible
- * for adding all constructor and member wrappers to the returned py::class_ object.
+ * for adding all constructor and member wrappers to the returned `py::class_` object.
+ *
+ * @tparam T The C++ exception to wrap.
+ * @tparam E The C++ base class of `T`.
+ *
+ * @param[in] mod Module to insert the exception into.
+ * @param[in] name Name of the exception in the module.
+ * @param[in] base Python name of base class (from pex::exceptions).
  */
 template <typename T, typename E = lsst::pex::exceptions::Exception>
 pybind11::class_<T> declareException(pybind11::module &mod, const std::string &name,

--- a/python/lsst/__init__.py
+++ b/python/lsst/__init__.py
@@ -1,9 +1,10 @@
+# This file is part of pex_exceptions.
 #
-# LSST Data Management System
-# Copyright 2008, 2009, 2010 LSST Corporation.
-#
-# This product includes software developed by the
-# LSST Project (http://www.lsst.org/).
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,10 +16,8 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the LSST License Statement and
-# the GNU General Public License along with this program.  If not,
-# see <http://www.lsstcorp.org/LegalNotices/>.
-#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import lsstimport, pkgutil
 __path__ = pkgutil.extend_path(__path__, __name__)

--- a/python/lsst/pex/exceptions/__init__.py
+++ b/python/lsst/pex/exceptions/__init__.py
@@ -1,9 +1,10 @@
+# This file is part of pex_exceptions.
 #
-# LSST Data Management System
-# Copyright 2008-2014 LSST Corporation.
-#
-# This product includes software developed by the
-# LSST Project (http://www.lsst.org/).
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,10 +16,8 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the LSST License Statement and
-# the GNU General Public License along with this program.  If not,
-# see <http://www.lsstcorp.org/LegalNotices/>.
-#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import absolute_import
 

--- a/python/lsst/pex/exceptions/exceptions.cc
+++ b/python/lsst/pex/exceptions/exceptions.cc
@@ -1,3 +1,26 @@
+/*
+ * This file is part of pex_exceptions.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include "pybind11/pybind11.h"
 
 #include <sstream>

--- a/python/lsst/pex/exceptions/exceptions.cc
+++ b/python/lsst/pex/exceptions/exceptions.cc
@@ -137,7 +137,7 @@ PYBIND11_PLUGIN(exceptions) {
     py::class_<RangeError, RuntimeError> clsRangeError(mod, "RangeError");
     clsRangeError.def(py::init<std::string const &>());
 
-    py::class_<TypeError, RuntimeError> clsTypeError(mod, "TypeError");
+    py::class_<TypeError, LogicError> clsTypeError(mod, "TypeError");
     clsTypeError.def(py::init<std::string const &>());
 
     py::class_<UnderflowError, RuntimeError> clsUnderflowError(mod, "UnderflowError");

--- a/python/lsst/pex/exceptions/exceptions.cc
+++ b/python/lsst/pex/exceptions/exceptions.cc
@@ -46,16 +46,20 @@ void tryLsstExceptionWarn(const char *message) {
     }
 }
 
-// Raise a Python exception that wraps the given C++ exception instance.
-//
-// Most of the work is delegated to the pure-Python function pex.exceptions.wrappers.translate(),
-// which looks up the appropriate Python exception class from a dict that maps C++ exception
-// types to their custom Python wrappers.  Everything else here is basically just importing that
-// module, preparing the arguments, and calling that function, along with the very verbose error
-// handling required by the Python C API.
-//
-// If any point we fail to translate the exception, we print a Python warning and raise the built-in
-// Python RuntimeError exception with the same message as the C++ exception.
+/**
+ * Raise a Python exception that wraps the given C++ exception instance.
+ *
+ * Most of the work is delegated to the pure-Python function pex.exceptions.wrappers.translate(),
+ * which looks up the appropriate Python exception class from a dict that maps C++ exception
+ * types to their custom Python wrappers.  Everything else here is basically just importing that
+ * module, preparing the arguments, and calling that function, along with the very verbose error
+ * handling required by the Python C API.
+ *
+ * If any point we fail to translate the exception, we print a Python warning and raise the built-in
+ * Python RuntimeError exception with the same message as the C++ exception.
+ *
+ * @param pyex a wrapped instance of pex::exceptions::Exception
+ */
 void raiseLsstException(py::object &pyex) {
     static auto module =
             py::reinterpret_borrow<py::object>(PyImport_ImportModule("lsst.pex.exceptions.wrappers"));

--- a/python/lsst/pex/exceptions/exceptions.cc
+++ b/python/lsst/pex/exceptions/exceptions.cc
@@ -58,7 +58,7 @@ void raiseLsstException(py::object &pyex) {
         }
     }
 }
-}  // <anonymous>
+}  // namespace
 
 PYBIND11_PLUGIN(exceptions) {
     py::module mod("exceptions");
@@ -141,6 +141,6 @@ PYBIND11_PLUGIN(exceptions) {
     return mod.ptr();
 }
 
-}  // exceptions
-}  // pex
-}  // lsst
+}  // namespace exceptions
+}  // namespace pex
+}  // namespace lsst

--- a/python/lsst/pex/exceptions/wrappers.py
+++ b/python/lsst/pex/exceptions/wrappers.py
@@ -1,3 +1,24 @@
+# This file is part of pex_exceptions.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 from __future__ import absolute_import
 
 __all__ = ["register", "ExceptionMeta", "Exception", "LogicError",

--- a/src/Exception.cc
+++ b/src/Exception.cc
@@ -44,7 +44,7 @@ Exception::Exception(char const* file, int line, char const* func, std::string c
 
 Exception::Exception(std::string const& message) : _message(message), _traceback() {}
 
-Exception::~Exception(void) throw() {}
+Exception::~Exception(void) noexcept {}
 
 void Exception::addMessage(char const* file, int line, char const* func, std::string const& message) {
     std::ostringstream stream;
@@ -76,7 +76,7 @@ void Exception::addMessage(char const* file, int line, char const* func, std::st
     _message = stream.str();
 }
 
-Traceback const& Exception::getTraceback(void) const throw() { return _traceback; }
+Traceback const& Exception::getTraceback(void) const noexcept { return _traceback; }
 
 std::ostream& Exception::addToStream(std::ostream& stream) const {
     if (_traceback.empty()) {
@@ -96,9 +96,9 @@ std::ostream& Exception::addToStream(std::ostream& stream) const {
     return stream;
 }
 
-char const* Exception::what(void) const throw() { return _message.c_str(); }
+char const* Exception::what(void) const noexcept { return _message.c_str(); }
 
-char const* Exception::getType(void) const throw() { return "lsst::pex::exceptions::Exception *"; }
+char const* Exception::getType(void) const noexcept { return "lsst::pex::exceptions::Exception *"; }
 
 Exception* Exception::clone(void) const { return new Exception(*this); }
 

--- a/src/Exception.cc
+++ b/src/Exception.cc
@@ -1,10 +1,11 @@
-// -*- lsst-c++ -*-
 /*
- * LSST Data Management System
- * Copyright 2008-2014 LSST Corporation.
+ * This file is part of pex_exceptions.
  *
- * This product includes software developed by the
- * LSST Project (http://www.lsst.org/).
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,9 +17,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the LSST License Statement and
- * the GNU General Public License along with this program.  If not,
- * see <http://www.lsstcorp.org/LegalNotices/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef __GNUC__

--- a/src/Exception.cc
+++ b/src/Exception.cc
@@ -22,7 +22,7 @@
  */
 
 #ifndef __GNUC__
-#  define __attribute__(x) /*NOTHING*/
+#define __attribute__(x) /*NOTHING*/
 #endif
 
 #include <cstring>
@@ -32,29 +32,21 @@
 
 #include "lsst/pex/exceptions/Exception.h"
 
-namespace lsst { namespace pex { namespace exceptions {
+namespace lsst {
+namespace pex {
+namespace exceptions {
 
-Tracepoint::Tracepoint(
-    char const* file, int line, char const* func,
-    std::string const& message
-) :
-    _file(file), _line(line), _func(func), _message(message)
-{}
+Tracepoint::Tracepoint(char const* file, int line, char const* func, std::string const& message)
+        : _file(file), _line(line), _func(func), _message(message) {}
 
-Exception::Exception(
-    char const* file, int line, char const* func,
-    std::string const& message
-) : _message(message), _traceback(1, Tracepoint(file, line, func, message)) {}
+Exception::Exception(char const* file, int line, char const* func, std::string const& message)
+        : _message(message), _traceback(1, Tracepoint(file, line, func, message)) {}
 
-Exception::Exception(
-    std::string const& message
-) : _message(message), _traceback() {}
+Exception::Exception(std::string const& message) : _message(message), _traceback() {}
 
 Exception::~Exception(void) throw() {}
 
-void Exception::addMessage(
-    char const* file, int line, char const* func, std::string const& message
-) {
+void Exception::addMessage(char const* file, int line, char const* func, std::string const& message) {
     std::ostringstream stream;
     stream << _message;
     if (_traceback.empty()) {
@@ -82,13 +74,9 @@ void Exception::addMessage(
         _traceback.push_back(Tracepoint(file, line, func, message));
     }
     _message = stream.str();
-
 }
 
-Traceback const&
-    Exception::getTraceback(void) const throw() {
-    return _traceback;
-}
+Traceback const& Exception::getTraceback(void) const throw() { return _traceback; }
 
 std::ostream& Exception::addToStream(std::ostream& stream) const {
     if (_traceback.empty()) {
@@ -96,11 +84,10 @@ std::ostream& Exception::addToStream(std::ostream& stream) const {
         // newlines, because Python will print those itself.
         stream << _message;
     } else {
-        stream << std::endl; // Start with a newline to separate our stuff from Pythons "<type>: " prefix.
+        stream << std::endl;  // Start with a newline to separate our stuff from Pythons "<type>: " prefix.
         for (std::size_t i = 0; i != _traceback.size(); ++i) {
-            stream << "  File \"" << _traceback[i]._file
-                   << "\", line " << _traceback[i]._line
-                   << ", in " << _traceback[i]._func << std::endl;
+            stream << "  File \"" << _traceback[i]._file << "\", line " << _traceback[i]._line << ", in "
+                   << _traceback[i]._func << std::endl;
             stream << "    " << _traceback[i]._message << " {" << i << "}" << std::endl;
         }
         std::string type(getType(), 0, std::strlen(getType()) - 2);
@@ -109,21 +96,14 @@ std::ostream& Exception::addToStream(std::ostream& stream) const {
     return stream;
 }
 
-char const* Exception::what(void) const throw() {
-    return _message.c_str();
-}
+char const* Exception::what(void) const throw() { return _message.c_str(); }
 
-char const* Exception::getType(void) const throw() {
-    return "lsst::pex::exceptions::Exception *";
-}
+char const* Exception::getType(void) const throw() { return "lsst::pex::exceptions::Exception *"; }
 
-Exception* Exception::clone(void) const {
-    return new Exception(*this);
-}
+Exception* Exception::clone(void) const { return new Exception(*this); }
 
-std::ostream& operator<<(
-    std::ostream& stream, Exception const& e) {
-    return e.addToStream(stream);
-}
+std::ostream& operator<<(std::ostream& stream, Exception const& e) { return e.addToStream(stream); }
 
-}}} // namespace lsst::pex::exceptions
+}  // namespace exceptions
+}  // namespace pex
+}  // namespace lsst

--- a/tests/testLib.cc
+++ b/tests/testLib.cc
@@ -1,3 +1,26 @@
+/*
+ * This file is part of pex_exceptions.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <string>
 
 #include <pybind11/pybind11.h>

--- a/tests/testLib.cc
+++ b/tests/testLib.cc
@@ -11,26 +11,24 @@ using namespace lsst::pex::exceptions;
 LSST_EXCEPTION_TYPE(TestError, lsst::pex::exceptions::RuntimeError, TestError)
 
 template <typename T>
-void fail1(std::string const & message) {
+void fail1(std::string const &message) {
     throw LSST_EXCEPT(T, message);
 }
 
 template <typename T>
-void fail2(std::string const & message1, std::string const & message2) {
+void fail2(std::string const &message1, std::string const &message2) {
     try {
         fail1<T>(message1);
-    } catch (T & err) {
+    } catch (T &err) {
         LSST_EXCEPT_ADD(err, message2);
         throw err;
-    }   
+    }
 }
 
-#define LSST_FAIL_TEST(name) \
-    mod.def("fail" #name "1", [](const std::string & message){ \
-            fail1<name>(message); \
-    }); \
-    mod.def("fail" #name "2", [](const std::string & message1, const std::string & message2){ \
-            fail2<name>(message1, message2); \
+#define LSST_FAIL_TEST(name)                                                                 \
+    mod.def("fail" #name "1", [](const std::string &message) { fail1<name>(message); });     \
+    mod.def("fail" #name "2", [](const std::string &message1, const std::string &message2) { \
+        fail2<name>(message1, message2);                                                     \
     });
 
 PYBIND11_PLUGIN(_testLib) {

--- a/tests/test_Exception_1.cc
+++ b/tests/test_Exception_1.cc
@@ -1,7 +1,7 @@
-/* 
+/*
  * LSST Data Management System
  * Copyright 2008, 2009, 2010 LSST Corporation.
- * 
+ *
  * This product includes software developed by the
  * LSST Project (http://www.lsst.org/).
  *
@@ -9,17 +9,17 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
- * You should have received a copy of the LSST License Statement and 
- * the GNU General Public License along with this program.  If not, 
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
  * see <http://www.lsstcorp.org/LegalNotices/>.
  */
- 
+
 #include "lsst/pex/exceptions/Exception.h"
 
 #define BOOST_TEST_MODULE Exception_1
@@ -38,19 +38,14 @@ namespace pexExcept = lsst::pex::exceptions;
 // that the output strings also depend on the name of this file and line
 // numbers within it, however.
 
-void f1(void) {
-    throw LSST_EXCEPT(pexExcept::Exception, "In f1");
-}
+void f1(void) { throw LSST_EXCEPT(pexExcept::Exception, "In f1"); }
 
-void f2(void) {
-    throw LSST_EXCEPT(ChildException, (boost::format("In f2 %1%") % 2008).str());
-}
+void f2(void) { throw LSST_EXCEPT(ChildException, (boost::format("In f2 %1%") % 2008).str()); }
 
 void f4(void) {
     try {
         f1();
-    }
-    catch (pexExcept::Exception& e) {
+    } catch (pexExcept::Exception& e) {
         LSST_EXCEPT_ADD(e, "In f4");
         throw;
     }
@@ -59,8 +54,7 @@ void f4(void) {
 void f5(void) {
     try {
         f2();
-    }
-    catch (pexExcept::Exception& e) {
+    } catch (pexExcept::Exception& e) {
         LSST_EXCEPT_ADD(e, "In f5");
         throw;
     }
@@ -69,8 +63,7 @@ void f5(void) {
 void f6(void) {
     try {
         f2();
-    }
-    catch (ChildException& e) {
+    } catch (ChildException& e) {
         LSST_EXCEPT_ADD(e, "In f6");
         throw;
     }
@@ -79,8 +72,7 @@ void f6(void) {
 void f7(void) {
     try {
         f6();
-    }
-    catch (ChildException& e) {
+    } catch (ChildException& e) {
         LSST_EXCEPT_ADD(e, "In f7");
         throw;
     }
@@ -101,181 +93,161 @@ BOOST_AUTO_TEST_CASE(simple) {
     test::output_test_stream o;
     try {
         f1();
-    }
-    catch (pexExcept::Exception const& e) {
+    } catch (pexExcept::Exception const& e) {
         o << e;
     }
     BOOST_CHECK(!o.is_empty(false));
-    BOOST_CHECK(o.is_equal(
-                    "\n"
-                    "  File \"tests/test_Exception_1.cc\", line 42, in void f1()\n"
-                    "    In f1 {0}\n"
-                    "lsst::pex::exceptions::Exception: 'In f1'\n"
-                ));
+    BOOST_CHECK(
+            o.is_equal("\n"
+                       "  File \"tests/test_Exception_1.cc\", line 41, in void f1()\n"
+                       "    In f1 {0}\n"
+                       "lsst::pex::exceptions::Exception: 'In f1'\n"));
 }
 
 BOOST_AUTO_TEST_CASE(child_as_base) {
     test::output_test_stream o;
     try {
         f2();
-    }
-    catch (pexExcept::Exception const& e) {
+    } catch (pexExcept::Exception const& e) {
         o << e;
     }
     BOOST_CHECK(!o.is_empty(false));
-    BOOST_CHECK(o.is_equal(
-                    "\n"
-                    "  File \"tests/test_Exception_1.cc\", line 46, in void f2()\n"
-                    "    In f2 2008 {0}\n"
-                    "ChildException: 'In f2 2008'\n"
-                ));
+    BOOST_CHECK(
+            o.is_equal("\n"
+                       "  File \"tests/test_Exception_1.cc\", line 43, in void f2()\n"
+                       "    In f2 2008 {0}\n"
+                       "ChildException: 'In f2 2008'\n"));
 }
 
 BOOST_AUTO_TEST_CASE(child_as_child) {
     test::output_test_stream o;
     try {
         f2();
-    }
-    catch (ChildException const& e) {
+    } catch (ChildException const& e) {
         o << e;
     }
     BOOST_CHECK(!o.is_empty(false));
-    BOOST_CHECK(o.is_equal(
-                    "\n"
-                    "  File \"tests/test_Exception_1.cc\", line 46, in void f2()\n"
-                    "    In f2 2008 {0}\n"
-                    "ChildException: 'In f2 2008'\n"
-                ));
+    BOOST_CHECK(
+            o.is_equal("\n"
+                       "  File \"tests/test_Exception_1.cc\", line 43, in void f2()\n"
+                       "    In f2 2008 {0}\n"
+                       "ChildException: 'In f2 2008'\n"));
 }
 
 BOOST_AUTO_TEST_CASE(simple_rethrow) {
     test::output_test_stream o;
     try {
         f4();
-    }
-    catch (pexExcept::Exception const& e) {
+    } catch (pexExcept::Exception const& e) {
         o << e;
     }
     BOOST_CHECK(!o.is_empty(false));
-    BOOST_CHECK(o.is_equal(
-                    "\n"
-                    "  File \"tests/test_Exception_1.cc\", line 42, in void f1()\n"
-                    "    In f1 {0}\n"
-                    "  File \"tests/test_Exception_1.cc\", line 54, in void f4()\n"
-                    "    In f4 {1}\n"
-                    "lsst::pex::exceptions::Exception: 'In f1 {0}; In f4 {1}'\n"
-                ));
+    BOOST_CHECK(
+            o.is_equal("\n"
+                       "  File \"tests/test_Exception_1.cc\", line 41, in void f1()\n"
+                       "    In f1 {0}\n"
+                       "  File \"tests/test_Exception_1.cc\", line 49, in void f4()\n"
+                       "    In f4 {1}\n"
+                       "lsst::pex::exceptions::Exception: 'In f1 {0}; In f4 {1}'\n"));
 }
 
 BOOST_AUTO_TEST_CASE(child_rethrow_base_as_base) {
     test::output_test_stream o;
     try {
         f5();
-    }
-    catch (pexExcept::Exception const& e) {
+    } catch (pexExcept::Exception const& e) {
         o << e;
     }
     BOOST_CHECK(!o.is_empty(false));
-    BOOST_CHECK(o.is_equal(
-                    "\n"
-                    "  File \"tests/test_Exception_1.cc\", line 46, in void f2()\n"
-                    "    In f2 2008 {0}\n"
-                    "  File \"tests/test_Exception_1.cc\", line 64, in void f5()\n"
-                    "    In f5 {1}\n"
-                    "ChildException: 'In f2 2008 {0}; In f5 {1}'\n"
-                ));
+    BOOST_CHECK(
+            o.is_equal("\n"
+                       "  File \"tests/test_Exception_1.cc\", line 43, in void f2()\n"
+                       "    In f2 2008 {0}\n"
+                       "  File \"tests/test_Exception_1.cc\", line 58, in void f5()\n"
+                       "    In f5 {1}\n"
+                       "ChildException: 'In f2 2008 {0}; In f5 {1}'\n"));
 }
 
 BOOST_AUTO_TEST_CASE(child_rethrow_base_as_child) {
     test::output_test_stream o;
     try {
         f5();
-    }
-    catch (ChildException const& e) {
+    } catch (ChildException const& e) {
         o << e;
     }
     BOOST_CHECK(!o.is_empty(false));
-    BOOST_CHECK(o.is_equal(
-                    "\n"
-                    "  File \"tests/test_Exception_1.cc\", line 46, in void f2()\n"
-                    "    In f2 2008 {0}\n"
-                    "  File \"tests/test_Exception_1.cc\", line 64, in void f5()\n"
-                    "    In f5 {1}\n"
-                    "ChildException: 'In f2 2008 {0}; In f5 {1}'\n"
-                ));
+    BOOST_CHECK(
+            o.is_equal("\n"
+                       "  File \"tests/test_Exception_1.cc\", line 43, in void f2()\n"
+                       "    In f2 2008 {0}\n"
+                       "  File \"tests/test_Exception_1.cc\", line 58, in void f5()\n"
+                       "    In f5 {1}\n"
+                       "ChildException: 'In f2 2008 {0}; In f5 {1}'\n"));
 }
 
 BOOST_AUTO_TEST_CASE(child_rethrow_child_as_base) {
     test::output_test_stream o;
     try {
         f6();
-    }
-    catch (pexExcept::Exception const& e) {
+    } catch (pexExcept::Exception const& e) {
         o << e;
     }
     BOOST_CHECK(!o.is_empty(false));
-    BOOST_CHECK(o.is_equal(
-                    "\n"
-                    "  File \"tests/test_Exception_1.cc\", line 46, in void f2()\n"
-                    "    In f2 2008 {0}\n"
-                    "  File \"tests/test_Exception_1.cc\", line 74, in void f6()\n"
-                    "    In f6 {1}\n"
-                    "ChildException: 'In f2 2008 {0}; In f6 {1}'\n"
-                ));
+    BOOST_CHECK(
+            o.is_equal("\n"
+                       "  File \"tests/test_Exception_1.cc\", line 43, in void f2()\n"
+                       "    In f2 2008 {0}\n"
+                       "  File \"tests/test_Exception_1.cc\", line 67, in void f6()\n"
+                       "    In f6 {1}\n"
+                       "ChildException: 'In f2 2008 {0}; In f6 {1}'\n"));
 }
 
 BOOST_AUTO_TEST_CASE(child_rethrow_child_as_child) {
     test::output_test_stream o;
     try {
         f6();
-    }
-    catch (ChildException const& e) {
+    } catch (ChildException const& e) {
         o << e;
     }
     BOOST_CHECK(!o.is_empty(false));
-    BOOST_CHECK(o.is_equal(
-                    "\n"
-                    "  File \"tests/test_Exception_1.cc\", line 46, in void f2()\n"
-                    "    In f2 2008 {0}\n"
-                    "  File \"tests/test_Exception_1.cc\", line 74, in void f6()\n"
-                    "    In f6 {1}\n"
-                    "ChildException: 'In f2 2008 {0}; In f6 {1}'\n"
-                ));
+    BOOST_CHECK(
+            o.is_equal("\n"
+                       "  File \"tests/test_Exception_1.cc\", line 43, in void f2()\n"
+                       "    In f2 2008 {0}\n"
+                       "  File \"tests/test_Exception_1.cc\", line 67, in void f6()\n"
+                       "    In f6 {1}\n"
+                       "ChildException: 'In f2 2008 {0}; In f6 {1}'\n"));
 }
 
 BOOST_AUTO_TEST_CASE(throw_without_macro) {
     test::output_test_stream o;
-    try { // this form shouldn't be used, but we don't want things to explode if it is
+    try {  // this form shouldn't be used, but we don't want things to explode if it is
         throw ChildException("python-only ctor");
-    } catch (ChildException & e) {
+    } catch (ChildException& e) {
         LSST_EXCEPT_ADD(e, "new message");
         o << e;
     }
     BOOST_CHECK(!o.is_empty(false));
-    BOOST_CHECK(o.is_equal(
-                    "python-only ctor; new message"
-                ));
+    BOOST_CHECK(o.is_equal("python-only ctor; new message"));
 }
 
 BOOST_AUTO_TEST_CASE(rethrow_twice) {
     test::output_test_stream o;
     try {
         f7();
-    }
-    catch (ChildException const& e) {
+    } catch (ChildException const& e) {
         o << e;
     }
     BOOST_CHECK(!o.is_empty(false));
-    BOOST_CHECK(o.is_equal(
-                    "\n"
-                    "  File \"tests/test_Exception_1.cc\", line 46, in void f2()\n"
-                    "    In f2 2008 {0}\n"
-                    "  File \"tests/test_Exception_1.cc\", line 74, in void f6()\n"
-                    "    In f6 {1}\n"
-                    "  File \"tests/test_Exception_1.cc\", line 84, in void f7()\n"
-                    "    In f7 {2}\n"
-                    "ChildException: 'In f2 2008 {0}; In f6 {1}; In f7 {2}'\n"
-                ));
+    BOOST_CHECK(
+            o.is_equal("\n"
+                       "  File \"tests/test_Exception_1.cc\", line 43, in void f2()\n"
+                       "    In f2 2008 {0}\n"
+                       "  File \"tests/test_Exception_1.cc\", line 67, in void f6()\n"
+                       "    In f6 {1}\n"
+                       "  File \"tests/test_Exception_1.cc\", line 76, in void f7()\n"
+                       "    In f7 {2}\n"
+                       "ChildException: 'In f2 2008 {0}; In f6 {1}; In f7 {2}'\n"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_Exception_1.cc
+++ b/tests/test_Exception_1.cc
@@ -1,9 +1,11 @@
 /*
- * LSST Data Management System
- * Copyright 2008, 2009, 2010 LSST Corporation.
+ * This file is part of pex_exceptions.
  *
- * This product includes software developed by the
- * LSST Project (http://www.lsst.org/).
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,9 +17,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the LSST License Statement and
- * the GNU General Public License along with this program.  If not,
- * see <http://www.lsstcorp.org/LegalNotices/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include "lsst/pex/exceptions/Exception.h"
@@ -99,7 +100,7 @@ BOOST_AUTO_TEST_CASE(simple) {
     BOOST_CHECK(!o.is_empty(false));
     BOOST_CHECK(
             o.is_equal("\n"
-                       "  File \"tests/test_Exception_1.cc\", line 41, in void f1()\n"
+                       "  File \"tests/test_Exception_1.cc\", line 42, in void f1()\n"
                        "    In f1 {0}\n"
                        "lsst::pex::exceptions::Exception: 'In f1'\n"));
 }
@@ -114,7 +115,7 @@ BOOST_AUTO_TEST_CASE(child_as_base) {
     BOOST_CHECK(!o.is_empty(false));
     BOOST_CHECK(
             o.is_equal("\n"
-                       "  File \"tests/test_Exception_1.cc\", line 43, in void f2()\n"
+                       "  File \"tests/test_Exception_1.cc\", line 44, in void f2()\n"
                        "    In f2 2008 {0}\n"
                        "ChildException: 'In f2 2008'\n"));
 }
@@ -129,7 +130,7 @@ BOOST_AUTO_TEST_CASE(child_as_child) {
     BOOST_CHECK(!o.is_empty(false));
     BOOST_CHECK(
             o.is_equal("\n"
-                       "  File \"tests/test_Exception_1.cc\", line 43, in void f2()\n"
+                       "  File \"tests/test_Exception_1.cc\", line 44, in void f2()\n"
                        "    In f2 2008 {0}\n"
                        "ChildException: 'In f2 2008'\n"));
 }
@@ -144,9 +145,9 @@ BOOST_AUTO_TEST_CASE(simple_rethrow) {
     BOOST_CHECK(!o.is_empty(false));
     BOOST_CHECK(
             o.is_equal("\n"
-                       "  File \"tests/test_Exception_1.cc\", line 41, in void f1()\n"
+                       "  File \"tests/test_Exception_1.cc\", line 42, in void f1()\n"
                        "    In f1 {0}\n"
-                       "  File \"tests/test_Exception_1.cc\", line 49, in void f4()\n"
+                       "  File \"tests/test_Exception_1.cc\", line 50, in void f4()\n"
                        "    In f4 {1}\n"
                        "lsst::pex::exceptions::Exception: 'In f1 {0}; In f4 {1}'\n"));
 }
@@ -161,9 +162,9 @@ BOOST_AUTO_TEST_CASE(child_rethrow_base_as_base) {
     BOOST_CHECK(!o.is_empty(false));
     BOOST_CHECK(
             o.is_equal("\n"
-                       "  File \"tests/test_Exception_1.cc\", line 43, in void f2()\n"
+                       "  File \"tests/test_Exception_1.cc\", line 44, in void f2()\n"
                        "    In f2 2008 {0}\n"
-                       "  File \"tests/test_Exception_1.cc\", line 58, in void f5()\n"
+                       "  File \"tests/test_Exception_1.cc\", line 59, in void f5()\n"
                        "    In f5 {1}\n"
                        "ChildException: 'In f2 2008 {0}; In f5 {1}'\n"));
 }
@@ -178,9 +179,9 @@ BOOST_AUTO_TEST_CASE(child_rethrow_base_as_child) {
     BOOST_CHECK(!o.is_empty(false));
     BOOST_CHECK(
             o.is_equal("\n"
-                       "  File \"tests/test_Exception_1.cc\", line 43, in void f2()\n"
+                       "  File \"tests/test_Exception_1.cc\", line 44, in void f2()\n"
                        "    In f2 2008 {0}\n"
-                       "  File \"tests/test_Exception_1.cc\", line 58, in void f5()\n"
+                       "  File \"tests/test_Exception_1.cc\", line 59, in void f5()\n"
                        "    In f5 {1}\n"
                        "ChildException: 'In f2 2008 {0}; In f5 {1}'\n"));
 }
@@ -195,9 +196,9 @@ BOOST_AUTO_TEST_CASE(child_rethrow_child_as_base) {
     BOOST_CHECK(!o.is_empty(false));
     BOOST_CHECK(
             o.is_equal("\n"
-                       "  File \"tests/test_Exception_1.cc\", line 43, in void f2()\n"
+                       "  File \"tests/test_Exception_1.cc\", line 44, in void f2()\n"
                        "    In f2 2008 {0}\n"
-                       "  File \"tests/test_Exception_1.cc\", line 67, in void f6()\n"
+                       "  File \"tests/test_Exception_1.cc\", line 68, in void f6()\n"
                        "    In f6 {1}\n"
                        "ChildException: 'In f2 2008 {0}; In f6 {1}'\n"));
 }
@@ -212,9 +213,9 @@ BOOST_AUTO_TEST_CASE(child_rethrow_child_as_child) {
     BOOST_CHECK(!o.is_empty(false));
     BOOST_CHECK(
             o.is_equal("\n"
-                       "  File \"tests/test_Exception_1.cc\", line 43, in void f2()\n"
+                       "  File \"tests/test_Exception_1.cc\", line 44, in void f2()\n"
                        "    In f2 2008 {0}\n"
-                       "  File \"tests/test_Exception_1.cc\", line 67, in void f6()\n"
+                       "  File \"tests/test_Exception_1.cc\", line 68, in void f6()\n"
                        "    In f6 {1}\n"
                        "ChildException: 'In f2 2008 {0}; In f6 {1}'\n"));
 }
@@ -241,11 +242,11 @@ BOOST_AUTO_TEST_CASE(rethrow_twice) {
     BOOST_CHECK(!o.is_empty(false));
     BOOST_CHECK(
             o.is_equal("\n"
-                       "  File \"tests/test_Exception_1.cc\", line 43, in void f2()\n"
+                       "  File \"tests/test_Exception_1.cc\", line 44, in void f2()\n"
                        "    In f2 2008 {0}\n"
-                       "  File \"tests/test_Exception_1.cc\", line 67, in void f6()\n"
+                       "  File \"tests/test_Exception_1.cc\", line 68, in void f6()\n"
                        "    In f6 {1}\n"
-                       "  File \"tests/test_Exception_1.cc\", line 76, in void f7()\n"
+                       "  File \"tests/test_Exception_1.cc\", line 77, in void f7()\n"
                        "    In f7 {2}\n"
                        "ChildException: 'In f2 2008 {0}; In f6 {1}; In f7 {2}'\n"));
 }

--- a/tests/test_Exception_1.h
+++ b/tests/test_Exception_1.h
@@ -1,7 +1,7 @@
-/* 
+/*
  * LSST Data Management System
  * Copyright 2008, 2009, 2010 LSST Corporation.
- * 
+ *
  * This product includes software developed by the
  * LSST Project (http://www.lsst.org/).
  *
@@ -9,17 +9,17 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
- * You should have received a copy of the LSST License Statement and 
- * the GNU General Public License along with this program.  If not, 
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
  * see <http://www.lsstcorp.org/LegalNotices/>.
  */
- 
+
 #ifndef Exception_1_h
 #define Exception_1_h
 

--- a/tests/test_Exception_1.h
+++ b/tests/test_Exception_1.h
@@ -1,9 +1,11 @@
 /*
- * LSST Data Management System
- * Copyright 2008, 2009, 2010 LSST Corporation.
+ * This file is part of pex_exceptions.
  *
- * This product includes software developed by the
- * LSST Project (http://www.lsst.org/).
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,9 +17,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the LSST License Statement and
- * the GNU General Public License along with this program.  If not,
- * see <http://www.lsstcorp.org/LegalNotices/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef Exception_1_h

--- a/tests/test_Exception_2.py
+++ b/tests/test_Exception_2.py
@@ -1,9 +1,10 @@
+# This file is part of pex_exceptions.
 #
-# LSST Data Management System
-# Copyright 2008-2014 LSST Corporation.
-#
-# This product includes software developed by the
-# LSST Project (http://www.lsst.org/).
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,10 +16,8 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the LSST License Statement and
-# the GNU General Public License along with this program.  If not,
-# see <http://www.lsstcorp.org/LegalNotices/>.
-#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from builtins import str
 


### PR DESCRIPTION
This PR applies common style fixes to `pex_exceptions` and adds the documentation agreed on in [RFC-448](https://jira.lsstcorp.org/browse/RFC-448).