### PR TITLE
DM-18855: Fix Python TypeError inheritance to match C++

### DIFF
--- a/include/lsst/pex/exceptions/Exception.h
+++ b/include/lsst/pex/exceptions/Exception.h
@@ -102,7 +102,7 @@ typedef std::vector<Tracepoint> Traceback;
  * in terms of the appropriate subclasses (e.g., catch RuntimeError to handle
  * all unknown errors).
  *
- * In Python, this exception inherits from `__builtin__.Exception`.
+ * In Python, this exception inherits from `builtins.Exception`.
  */
 class LSST_EXPORT Exception : public std::exception {
 public:

--- a/include/lsst/pex/exceptions/Runtime.h
+++ b/include/lsst/pex/exceptions/Runtime.h
@@ -96,7 +96,7 @@ LSST_EXCEPTION_TYPE(OutOfRangeError, LogicError, lsst::pex::exceptions::OutOfRan
  * of calling a function or method even in well-written programs, and should be
  * handled at the appropriate level.
  *
- * In Python, this exception inherits from `__builtin__.RuntimeError`.
+ * In Python, this exception inherits from `builtins.RuntimeError`.
  *
  * @see LogicError
  * @see std::runtime_error
@@ -117,7 +117,7 @@ LSST_EXCEPTION_TYPE(RangeError, RuntimeError, lsst::pex::exceptions::RangeError)
 /**
  * Reports when the result of an arithmetic operation is too large for the destination type.
  *
- * In Python, this exception inherits from `__builtin__.OverflowError`.
+ * In Python, this exception inherits from `builtins.OverflowError`.
  *
  * @see std::overflow_error
  */
@@ -126,7 +126,7 @@ LSST_EXCEPTION_TYPE(OverflowError, RuntimeError, lsst::pex::exceptions::Overflow
 /**
  * Reports when the result of an arithmetic operation is too small for the destination type.
  *
- * In Python, this exception inherits from `__builtin__.ArithmeticError`.
+ * In Python, this exception inherits from `builtins.ArithmeticError`.
  *
  * @see std::underflow_error
  */
@@ -139,7 +139,7 @@ LSST_EXCEPTION_TYPE(UnderflowError, RuntimeError, lsst::pex::exceptions::Underfl
  * maps or Python dictionaries, but it may also be used when the relationship
  * between an identifier and a resource is more abstract.
  *
- * In Python, this exception inherits from `__builtin__.LookupError`.
+ * In Python, this exception inherits from `builtins.LookupError`.
  *
  * @see OutOfRangeError
  *
@@ -153,7 +153,7 @@ LSST_EXCEPTION_TYPE(NotFoundError, Exception, lsst::pex::exceptions::NotFoundErr
 /**
  * Reports errors in external input/output operations.
  *
- * In Python, this exception inherits from `__builtin__.IOError`.
+ * In Python, this exception inherits from `builtins.IOError`.
  *
  * @see std::ios_base::failure
  */
@@ -162,7 +162,7 @@ LSST_EXCEPTION_TYPE(IoError, RuntimeError, lsst::pex::exceptions::IoError)
 /**
  * Reports errors from accepting an object of an unexpected or inappropriate type.
  *
- * In Python, this exception inherits from `__builtin__.TypeError`.
+ * In Python, this exception inherits from `builtins.TypeError`.
  */
 LSST_EXCEPTION_TYPE(TypeError, LogicError, lsst::pex::exceptions::TypeError)
 

--- a/include/lsst/pex/exceptions/python/Exception.h
+++ b/include/lsst/pex/exceptions/python/Exception.h
@@ -49,7 +49,7 @@ namespace python {
  * @param[in] base Python name of base class (from pex::exceptions).
  */
 template <typename T, typename E = lsst::pex::exceptions::Exception>
-pybind11::class_<T> declareException(pybind11::module &mod, const std::string &name,
+pybind11::class_<T, E> declareException(pybind11::module &mod, const std::string &name,
                                      const std::string &base) {
     namespace py = pybind11;
 

--- a/python/lsst/pex/exceptions/wrappers.py
+++ b/python/lsst/pex/exceptions/wrappers.py
@@ -136,7 +136,7 @@ class IoError(RuntimeError, IOError):
 
 
 @register
-class TypeError(RuntimeError, TypeError):
+class TypeError(LogicError, TypeError):
     WrappedClass = exceptions.TypeError
 
 

--- a/tests/test_Exception_2.py
+++ b/tests/test_Exception_2.py
@@ -124,7 +124,7 @@ class ExceptionTestCase(unittest.TestCase):
                              IOError])
         self.checkHierarchy(testLib.failTypeError1,
                             [lsst.pex.exceptions.TypeError,
-                             lsst.pex.exceptions.RuntimeError,
+                             lsst.pex.exceptions.LogicError,
                              lsst.pex.exceptions.Exception,
                              TypeError])
 


### PR DESCRIPTION
`lsst.pex.exceptions.TypeError` no longer inherits from `RuntimeError`.